### PR TITLE
Fixing saving json on linux

### DIFF
--- a/rose-offline-server/src/game/storage/account.rs
+++ b/rose-offline-server/src/game/storage/account.rs
@@ -93,12 +93,14 @@ impl AccountStorage {
             )
         })?;
 
-        let mut file = tempfile::NamedTempFile::new().with_context(|| {
-            format!(
-                "Failed to create temporary file whilst saving account {}",
-                &self.name
-            )
-        })?;
+        let mut file = tempfile::Builder::new()
+            .tempfile_in(storage_dir)
+            .with_context(|| {
+                format!(
+                    "Failed to create temporary file whilst saving account {}",
+                    &self.name
+                )
+            })?;
         file.write_all(json.as_bytes()).with_context(|| {
             format!(
                 "Failed to write data to temporary file whilst saving account {}",

--- a/rose-offline-server/src/game/storage/bank.rs
+++ b/rose-offline-server/src/game/storage/bank.rs
@@ -68,12 +68,14 @@ impl BankStorage {
             )
         })?;
 
-        let mut file = tempfile::NamedTempFile::new().with_context(|| {
-            format!(
-                "Failed to create temporary file whilst saving bank for account {}",
-                account_name
-            )
-        })?;
+        let mut file = tempfile::Builder::new()
+            .tempfile_in(storage_dir)
+            .with_context(|| {
+                format!(
+                    "Failed to create temporary file whilst saving bank for account {}",
+                    account_name
+                )
+            })?;
         file.write_all(json.as_bytes()).with_context(|| {
             format!(
                 "Failed to write data to temporary file whilst saving bank for account {}",

--- a/rose-offline-server/src/game/storage/clan.rs
+++ b/rose-offline-server/src/game/storage/clan.rs
@@ -110,18 +110,20 @@ impl ClanStorage {
             )
         })?;
 
-        let json = serde_json::to_string_pretty(self).with_context(|| {
+        let json = serde_json::to_string_pretty(&self).with_context(|| {
             format!(
                 "Failed to serialise ClanStorage whilst saving clan {}",
                 &self.name
             )
         })?;
-        let mut file = tempfile::NamedTempFile::new().with_context(|| {
-            format!(
-                "Failed to create temporary file whilst saving clan {}",
-                &self.name
-            )
-        })?;
+        let mut file = tempfile::Builder::new()
+            .tempfile_in(storage_dir)
+            .with_context(|| {
+                format!(
+                    "Failed to create temporary file whilst saving clan {}",
+                    &self.name
+                )
+            })?;
         file.write_all(json.as_bytes()).with_context(|| {
             format!(
                 "Failed to write data to temporary file whilst saving clan {}",

--- a/rose-offline-server/src/game/systems/world_server_system.rs
+++ b/rose-offline-server/src/game/systems/world_server_system.rs
@@ -191,7 +191,7 @@ pub fn world_server_system(
                             hair as u8,
                         ) {
                             Ok(character) => {
-                                if let Err(error) = character.try_create() {
+                                if let Err(error) = character.try_create(&name) {
                                     log::error!(
                                         "Failed to create character {} with error {:?}",
                                         &name,


### PR DESCRIPTION
Moving files from a temp filesystem and moving to another is not allowed on linux, therefore saving was not working. Tested on windows and linux