### PR TITLE
Add chat command to search items and use human-readable types in /drop and /item

### DIFF
--- a/rose-data/src/item_database.rs
+++ b/rose-data/src/item_database.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
 use crate::{
-    AbilityType, EffectFileId, EffectId, JobClassId, SkillId, SoundId, StatusEffectId,
+    AbilityType, DataDecoder, EffectFileId, EffectId, JobClassId, SkillId, SoundId, StatusEffectId,
     StringDatabase, VehiclePartIndex,
 };
 
@@ -166,6 +166,37 @@ impl ItemType {
                 | ItemType::SubWeapon
                 | ItemType::Vehicle
         )
+    }
+
+    pub fn try_from_str(s: &str) -> Option<Self> {
+        match s {
+            "face" => Some(Self::Face),
+            "head" => Some(Self::Head),
+            "body" => Some(Self::Body),
+            "hands" => Some(Self::Hands),
+            "feet" => Some(Self::Feet),
+            "back" => Some(Self::Back),
+            "jewelry" => Some(Self::Jewellery),
+            "weapon" => Some(Self::Weapon),
+            "subweapon" => Some(Self::SubWeapon),
+            "consumable" => Some(Self::Consumable),
+            "gem" => Some(Self::Gem),
+            "material" => Some(Self::Material),
+            "quest" => Some(Self::Quest),
+            "vehicle" => Some(Self::Vehicle),
+            _ => None,
+        }
+    }
+
+    pub fn try_from_id_str<'a>(
+        s: &str,
+        gd: &'a impl AsRef<dyn DataDecoder + Send + Sync>,
+    ) -> Option<Self> {
+        if let Ok(item_type_id) = s.parse::<usize>() {
+            gd.as_ref().decode_item_type(item_type_id)
+        } else {
+            Self::try_from_str(s)
+        }
     }
 }
 

--- a/rose-offline-server/src/game/storage/character.rs
+++ b/rose-offline-server/src/game/storage/character.rs
@@ -84,7 +84,11 @@ impl CharacterStorage {
         self.save_character_impl(&self.info.name, true)
     }
 
-    fn save_character_impl(&self, character_name: &str, allow_overwrite: bool) -> Result<(), anyhow::Error> {
+    fn save_character_impl(
+        &self,
+        character_name: &str,
+        allow_overwrite: bool,
+    ) -> Result<(), anyhow::Error> {
         let path = get_character_path(character_name);
         let storage_dir = path.parent().unwrap();
 


### PR DESCRIPTION
I can split this up if you would like, and there's no expectation for a merge. Figured this might be helpful though (certainly was for me).

- Adds `/search <type> [search term]` to allow you to search through the item database
- Allows `/drop` and `/item` to take either a type ID (old behavior) or a human-readable type name (such as `body`, `face`, `weapon`, etc.)